### PR TITLE
Add CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Guardrails, policy engines, and governance frameworks for multi-agent systems.
 - [SEMAG: Self-Evolutionary Multi-Agent Code Generation](https://arxiv.org/abs/2603.15707) (arXiv'26) - Self-evolutionary agents that auto-upgrade backbone models.
 - [SAGE: Multi-Agent Self-Evolution for LLM Reasoning](https://arxiv.org/abs/2603.15255) (arXiv'26) - Four co-evolving agents from shared LLM backbone.
 - [Group-Evolving Agents](https://arxiv.org/abs/2602.04837) (arXiv'26) - Agent groups as evolutionary units with experience sharing. 71.0% on SWE-bench Verified.
+- [CORAL: Autonomous Multi-Agent Evolution for Open-Ended Discovery](https://arxiv.org/abs/2604.01658) (arXiv'26) - Long-running multi-agent systems that self-evolve via shared persistent memory, asynchronous execution, and heartbeat-based interventions.
 
 ### Role-Based Teams and Software Engineering
 


### PR DESCRIPTION
Hi — thanks for maintaining this awesome list!

I'd like to suggest adding our recent paper, **CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery**, which we think fits the scope of this list (self-evolving / autonomous multi-agent systems for open-ended discovery).

- **Paper:** https://arxiv.org/abs/2604.01658
- **Project page:** https://human-agent-society.github.io/CORAL/
- **Code:** https://github.com/Human-Agent-Society/CORAL

**TL;DR:** CORAL is the first framework for autonomous multi-agent evolution on open-ended problems. It replaces fixed heuristics and hard-coded exploration rules with long-running agents that explore, reflect, and collaborate through shared persistent memory, asynchronous multi-agent execution, and heartbeat-based interventions. It sets new SOTA on 10 math / algorithmic / systems-optimization tasks, with 3–10× higher improvement rates than fixed evolutionary-search baselines — and on Anthropic's kernel-engineering task, four co-evolving agents improve the best-known score from 1363 → 1103 cycles.

**BibTeX:**

```bibtex
@article{coral2026,
  title  = {CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery},
  author = {Qu, Ao and Zheng, Han and Zhou, Zijian and Yan, Yihao and Tang, Yihong and Ong, Shao Yong and Hong, Fenglu and Zhou, Kaichen and Jiang, Chonghe and Kong, Minwei and Zhu, Jiacheng and Jiang, Xuan and Li, Sirui and Wu, Cathy and Low, Bryan Kian Hsiang and Zhao, Jinhua and Liang, Paul Pu},
  journal = {arXiv preprint arXiv:2604.01658},
  year   = {2026},
  url    = {https://arxiv.org/abs/2604.01658}
}
```

Happy to reformat the entry or move it to a different section if you'd prefer — just let me know. Thanks for considering!
