### PR TITLE
ci: migrate ubuntu-latest -> self-hosted runner

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   monitor:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/update-stars.yml
+++ b/.github/workflows/update-stars.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Routes Linux CI jobs to the EvoMap self-hosted runner (evomap-shoot, Debian 12, 8 cores, 31G RAM).

Affected files in this repo:
  - .github/workflows/check-links.yml
  - .github/workflows/monitor.yml
  - .github/workflows/update-stars.yml

Skipped across the org where ubuntu-latest is load-bearing (glibc pin, cross-platform matrix, deliberately paid runner).

If CI fails on this runner due to missing tooling, install via setup-* actions or open an issue. Revert with `git revert` on this commit.

Auto-merge is enabled — will land when required checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only runner labels change; workflow logic and secrets usage are the same, with the main risk being self-hosted runner availability or missing tooling.
> 
> **Overview**
> **Routes scheduled and manual GitHub Actions jobs off GitHub-hosted `ubuntu-latest` onto the org’s Linux x64 self-hosted runner** via the repository variable `vars.CI_LABEL_LINUX_X64`.
> 
> The change is limited to the `runs-on` label in three workflows: **Check Links**, **Weekly Monitor**, and **Update Star Counts**. Triggers, permissions, Node setup, and script steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf97bf0159f0864eeac95b843e68dcad49d6f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->