### PR TITLE
ci: publish scheduled main updates only after validate

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   issues: read
+  checks: write
 
 jobs:
   monitor:
@@ -25,10 +26,17 @@ jobs:
         run: |
           node scripts/monitor-github.js --output data/monitor-results.json
 
-      - name: Commit results
+      - name: Commit and publish to main after validate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/monitor-results.json
-          git diff --staged --quiet || git commit -m "chore: update monitor results $(date -u +%Y-%m-%d)"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git checkout -B "chore/monitor-$(date -u +%Y%m%d)"
+          git commit -m "chore: update monitor results $(date -u +%Y-%m-%d)"
+          bash scripts/push-verified-main.sh

--- a/.github/workflows/update-stars.yml
+++ b/.github/workflows/update-stars.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  checks: write
 
 jobs:
   update:
@@ -26,10 +27,17 @@ jobs:
       - name: Regenerate README
         run: node scripts/generate-readme.js
 
-      - name: Commit changes
+      - name: Commit and publish to main after validate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/projects.json README.md
-          git diff --staged --quiet || git commit -m "chore: update star counts $(date -u +%Y-%m-%d)"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git checkout -B "chore/update-stars-$(date -u +%Y%m%d)"
+          git commit -m "chore: update star counts $(date -u +%Y-%m-%d)"
+          bash scripts/push-verified-main.sh

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,16 @@ on:
       - 'scripts/validate.js'
       - 'CONTRIBUTING.md'
       - '.github/workflows/**'
+  push:
+    branches:
+      - 'chore/**'
+    paths:
+      - 'README.md'
+      - 'data/**'
+      - 'scripts/generate-readme.js'
+      - 'scripts/validate.js'
+      - 'CONTRIBUTING.md'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 permissions:

--- a/scripts/push-verified-main.sh
+++ b/scripts/push-verified-main.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Publish a local chore/* commit to main after running the same validate gate
+# that pull requests use. Scheduled workflows cannot rely on a follow-up
+# validate.yml run: GITHUB_TOKEN pushes do not trigger other workflows, and
+# the GitHub Actions app cannot be added as a ruleset bypass actor here.
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+SHA=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ "$BRANCH" != chore/* ]]; then
+  echo "refusing to publish from $BRANCH (expected chore/*)" >&2
+  exit 1
+fi
+
+echo "Running validate on ${SHA} (${BRANCH})"
+node scripts/validate.js
+node scripts/generate-readme.js
+git diff --exit-code -- README.md
+
+git push origin "HEAD:refs/heads/${BRANCH}"
+
+check_payload=(
+  --field name=validate
+  --field head_sha="${SHA}"
+  --field status=completed
+  --field conclusion=success
+)
+if [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
+  check_payload+=(--field "details_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}")
+fi
+gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" "${check_payload[@]}"
+
+git push origin "${SHA}:refs/heads/main"
+git push origin --delete "${BRANCH}" || true
+echo "Published ${SHA} to main"


### PR DESCRIPTION
Enables requiring the `validate` check on `main` without breaking Wednesday star updates or Monday monitor commits.

**Why:** GitHub Actions (app 15368) cannot be a ruleset bypass actor on this org, and `GITHUB_TOKEN` pushes do not start other workflows. Direct `git push` to `main` from scheduled jobs would fail once `validate` is required.

**What changed**
- `scripts/push-verified-main.sh` commits stay on `chore/*`, run `node scripts/validate.js` plus a clean `generate-readme.js` diff, attach a `validate` check run to that SHA, then fast-forward `main`.
- `update-stars.yml` / `monitor.yml` use that helper (`checks: write`).
- `validate.yml` also runs on `push` to `chore/**` for human-pushed chore branches.

Does not merge itself. After this lands, the `Protect main` ruleset will add required status check `validate`.