### PR TITLE
ci: run validate on every pull request into main

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,13 +2,8 @@ name: Validate curated data
 
 on:
   pull_request:
-    paths:
-      - 'README.md'
-      - 'data/**'
-      - 'scripts/generate-readme.js'
-      - 'scripts/validate.js'
-      - 'CONTRIBUTING.md'
-      - '.github/workflows/**'
+    branches:
+      - main
   push:
     branches:
       - 'chore/**'


### PR DESCRIPTION
## What does this PR do?

The `Protect main` ruleset requires the `validate` check and has no bypass actor. `validate.yml` previously used a `pull_request` path filter, so a PR that only changed files such as `scripts/check-links.js`, `scripts/update-stars.js`, or docs outside that filter never posted the check. Merge then stayed blocked.

This drops the path filter on `pull_request` and keeps the job limited to PRs targeting `main`, so every PR into the default branch gets a `validate` check.

## Trigger before

```yaml
on:
  pull_request:
    paths:
      - 'README.md'
      - 'data/**'
      - 'scripts/generate-readme.js'
      - 'scripts/validate.js'
      - 'CONTRIBUTING.md'
      - '.github/workflows/**'
  push:
    branches:
      - 'chore/**'
    paths:
      - 'README.md'
      - 'data/**'
      - 'scripts/generate-readme.js'
      - 'scripts/validate.js'
      - 'CONTRIBUTING.md'
      - '.github/workflows/**'
  workflow_dispatch:
```

## Trigger after

```yaml
on:
  pull_request:
    branches:
      - main
  push:
    branches:
      - 'chore/**'
    paths:
      - 'README.md'
      - 'data/**'
      - 'scripts/generate-readme.js'
      - 'scripts/validate.js'
      - 'CONTRIBUTING.md'
      - '.github/workflows/**'
  workflow_dispatch:
```

## What did not change

- `push` to `chore/**` still uses the same path filter (scheduled publish).
- `scripts/push-verified-main.sh` remains the main-publish path. This workflow still does not run on `push` to `main` (`GITHUB_TOKEN` pushes do not trigger other workflows).
- Job id stays `validate`. Permissions stay `contents: read`. Runner stays `ubuntu-latest` with `checkout@v6`, `setup-node@v6`, Node 24, and the two existing steps.
- No bypass actor, no self-hosted runners, no auto-merge.

## Local verification

- `node scripts/validate.js`: Validated 56 projects across 9 categories; Validation passed.
- `node scripts/generate-readme.js`: idempotent (`git diff --exit-code -- README.md`)
- `git diff --check`: clean
- `data/projects.json` is untouched

Does not merge itself.